### PR TITLE
Fix handling contents added after header creation

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -444,7 +444,8 @@ fn append_path_with_name(
     };
     let ar_name = name.unwrap_or(path);
     if stat.is_file() {
-        append_fs(dst, ar_name, &stat, &mut fs::File::open(path)?, mode, None)
+        let file = fs::File::open(path)?;
+        append_fs(dst, ar_name, &stat, &mut file.take(stat.len()), mode, None)
     } else if stat.is_dir() {
         append_fs(dst, ar_name, &stat, &mut io::empty(), mode, None)
     } else if stat.file_type().is_symlink() {
@@ -520,7 +521,7 @@ fn append_file(
     mode: HeaderMode,
 ) -> io::Result<()> {
     let stat = file.metadata()?;
-    append_fs(dst, path, &stat, file, mode, None)
+    append_fs(dst, path, &stat, &mut file.take(stat.len()), mode, None)
 }
 
 fn append_dir(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -120,9 +120,8 @@ impl<W: Write> Builder<W> {
     /// header will be modified.
     ///
     /// Then it will append the header, followed by contents of the stream
-    /// specified by `data`, with the `size` field of `header` enforced as an
-    /// upper limit. To produce a valid archive the `size` field of `header`
-    /// must be less than or equal to the length of the stream that's being
+    /// specified by `data`. To produce a valid archive the `size` field of
+    /// `header` must be the same as the length of the stream that's being
     /// written.
     ///
     /// Note that this will not attempt to seek the archive to a valid position,
@@ -407,13 +406,9 @@ impl<W: Write> Builder<W> {
     }
 }
 
-fn append(mut dst: &mut dyn Write, header: &Header, data: &mut dyn Read) -> io::Result<()> {
+fn append(mut dst: &mut dyn Write, header: &Header, mut data: &mut dyn Read) -> io::Result<()> {
     dst.write_all(header.as_bytes())?;
-    // Guards against there being more data than the header indicates in the case where contents
-    // have been appended to the file since the header was created.
-    let size = header.size()?;
-    let mut limited = data.take(size);
-    let len = io::copy(&mut limited, &mut dst)?;
+    let len = io::copy(&mut data, &mut dst)?;
 
     // Pad with zeros if necessary.
     let buf = [0; 512];


### PR DESCRIPTION
Second attempt at fixing https://github.com/alexcrichton/tar-rs/issues/282, updated with the PR feedback: https://github.com/alexcrichton/tar-rs/pull/283#issuecomment-1058499564.

Just undoes the first set of changes and then adds https://github.com/PhysicalGraph/tar-rs/commit/378fdb2adf578fbd2049458518908ed13bd82347.

> Oh sorry I can generalize what I'm thinking a bit from "application layer" to "callers of this function". This is almost surely a bug in `append_dir_all` and it's fine to fix there, I just don't think it should be fixed in `append` which takes a generic input stream

What is here moves the changes up from `append` to `append_path_with_name` and  `append_file`.  At present I'm not really sure how to move things up higher to `append_dir_all` - at least without it being a more invasive set of changes.

Secondly, there now isn't really any point at which I can inject the issue reliably in a test situation.  Which doesn't feel great to try to land this without adding test coverage.

Hoping to get some feedback from folks here, especially if people have ideas on if / how to address these two points before resubmitting for review upstream.