### PR TITLE
[CHAD-16432] Make file appends safe in the case the file gets truncated mid-read

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::io::prelude::*;
 use std::path::Path;
 use std::str;
+use crate::safe_reader::SafeTruncateReader;
 
 use crate::header::{path2bytes, HeaderMode};
 use crate::{other, EntryType, Header};
@@ -521,7 +522,8 @@ fn append_file(
     mode: HeaderMode,
 ) -> io::Result<()> {
     let stat = file.metadata()?;
-    append_fs(dst, path, &stat, &mut file.take(stat.len()), mode, None)
+    let safe_reader = SafeTruncateReader::new(&*file)?;
+    append_fs(dst, path, &stat, &mut safe_reader.take(stat.len()), mode, None)
 }
 
 fn append_dir(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod entry_type;
 mod error;
 mod header;
 mod pax;
+mod safe_reader;
 
 fn other(msg: &str) -> Error {
     Error::new(ErrorKind::Other, msg)

--- a/src/safe_reader.rs
+++ b/src/safe_reader.rs
@@ -1,0 +1,47 @@
+use std::io::{self, Read};
+use std::fs::File;
+
+pub struct SafeTruncateReader<'a> {
+    file: &'a File,
+    expected_size: u64,
+    bytes_read: u64,
+}
+
+impl<'a> SafeTruncateReader<'a> {
+    pub fn new(file: &'a File) -> io::Result<Self> {
+        let expected_size = file.metadata()?.len();
+        Ok(Self {
+            file,
+            expected_size,
+            bytes_read: 0,
+        })
+    }
+}
+
+impl Read for SafeTruncateReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.bytes_read >= self.expected_size {
+            return Ok(0);
+        }
+        
+        let remaining = (self.expected_size - self.bytes_read) as usize;
+        let to_read = buf.len().min(remaining);
+        
+        match self.file.read(&mut buf[..to_read]) {
+            Ok(0) if self.bytes_read < self.expected_size => {
+                // File was truncated - pad with zeros to maintain valid tar
+                let pad_amount = to_read.min(buf.len());
+                for i in 0..pad_amount {
+                    buf[i] = 0;
+                }
+                self.bytes_read += pad_amount as u64;
+                Ok(pad_amount)
+            }
+            Ok(n) => {
+                self.bytes_read += n as u64;
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}


### PR DESCRIPTION
Creating archives using `tar-rs` currently fails if the file is truncated during archive creation. As we primarily use this crate to create log dump archives from `hubcore`, we expect files to occasionally be truncated due to log rolling. We therefore need this crate to be able to handle truncated 

Fixes the bug reported in [CHAD-16432](https://smartthings.atlassian.net/browse/CHAD-16432)

## Background

We originally forked this `tar-rs` crate from the [upstream repo](https://github.com/alexcrichton/tar-rs) in 2022 because the implementation does not handle creating archives on files which have content appended while the archive is being created. Grant created a patch and [PR to get this fix upstreamed](https://github.com/alexcrichton/tar-rs/pull/283). The maintainer rejected the PR because the crate was not written to support concurrent file system interactions. Therefore, we forked.

Grant's patch fixes the case where a file is appended to during archive creation. However, there is also the truncate case we need to handle.

We see truncation of files being archived which logs are rolled. We see this regularly with the tcp dump pcap files when an update is downloading. If you dump a log while an update is being downloaded, there is a very high likelyhood the log dump archive will be corrupted.

The corruption happens due to the tar file format. The header is written first, then the file contents. The header contains the length of the file. Therefore, if the file length changes while writing, the length of the written file contents do not match the length in the header.

GNU tar handles the truncate case by filling in the remaining expected length with zeros: https://github.com/Distrotech/tar/blob/273975bec1ff7d591d7ab8a63c08a02a285ffad3/src/create.c#L1058C1-L1073C3

We replicate the GNU tar behavior in this PR of filling in the expected length with zeros if the file size shrinks during the archive creation.

We primarily use this `tar-rs` crate for log dumps. It is pulled in as a dependency of `hubCore`: https://github.ecodesamsung.com/iot-hub/hub-core/blob/cef6d315576ebc594356e617ea7196c1ec3db711/rust/Cargo.toml#L836

## Implementation

This change adds a `SafeTruncateReader` wrapper around a file. The wrapper implements the `std::io::Read` method. When the file is first opened, the file's current size is read from the file metadata.

When the wrapper's read method is called, the wrapper calls the file's read method. If zero bytes are read and we haven't yet read the file's original expected length, we pad the buffer with zeros until we reach that expected length.

## Testing

I tested this by building the changeset into `hubcore`, then dumping multiple logs while updates were downloading to the hub. Without this change, the archive was corrupted the majority of the time. With this change, I never saw a corrupted log dump.

[CHAD-16432]: https://smartthings.atlassian.net/browse/CHAD-16432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ